### PR TITLE
 Fix indicator rotation base value

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
             const mins =
                 (date.getMinutes() + MINS_IN_HOUR - START_MINUTE) % MINS_IN_HOUR;
             const secs = date.getSeconds();
-            const ms = date.getMilliseconds();
+            const ms = date.getTime();
 
             // Clock matrix. row:column -> hour:minute
             const clockMatrix = new Array(HOURS_IN_DAY);


### PR DESCRIPTION
Since `getMilliseconds()` returns a value `0..999` (inclusive), it previously was not possible to use a delay of `250` and an indicator array length of `5`, as `0/250=0` and `999/250=3`, meaning that the last element could never be reached.

Instead, we should use `getTime()`.