### PR TITLE
Add UTF-8 meta

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <html>
     <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta charset="UTF-8">
         <style>
             body {
                 background-color: black;


### PR DESCRIPTION
When serving via IntelliJ IDEA, these characters would be displayed incorrectly: `['˺', '˼', '˻', '˹']`. Adding the UTF-8 meta encoding tag solves this.