### PR TITLE
Fix timezone display for negative offsets

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
             );
 
             return `${year}-${month}-${day} ${hour}:${min}:${sec}:${ms} (UTC${
-                tzhour < 0 ? '+' + tzhour : '-' + tzhour
+                tzhour < 0 ? '+' + (-tzhour) : '-' + tzhour
             }:${tzmin})`;
         };
 


### PR DESCRIPTION
For my timezone with `offset = -120`, `tz` would be `-2`, and would be displayed as `(UTC+-2)`, where the actual offset should be displayed as `UTC+2`.